### PR TITLE
Update parser for new archive format

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 1. Install all the dependencies
 2. Download/clone this repository
 3. On Facebook, go to Settings then select "Download a copy of your Facebook data"
-4. Once you have that, find `messages.htm` inside the html folder and move that to the same folder as this repository
+4. Once you have that, find the `messages` folder inside the archive and copy that folder into your clone of this repository
+    - This folder should keep the same name (`messages`) and be placed at the top level of the repo
 5. Edit `userinfo.py` and add your information
 6. Run `python parser.py`
 7. Run `python grapher.py`

--- a/parser.py
+++ b/parser.py
@@ -78,12 +78,12 @@ for convo_file in os.listdir("messages"): # Iterate through each conversation fi
             person_sending = item.contents[0].contents[0].contents[0]
             sent_by_me = (person_sending == ME)
 
-            if person in name_to_sex.keys():
+            sex = "unknown"
+            if person in name_to_sex:
                 sex = name_to_sex[person]
             else:
-                if person not in name_to_sex:
-                    sex = get_sex(person)
-                    name_to_sex[person] = sex
+                sex = get_sex(person)
+                name_to_sex[person] = sex
 
             messages.append(Message(person, sent_by_me, timestamp, sex))
 

--- a/userinfo.py
+++ b/userinfo.py
@@ -1,3 +1,7 @@
+"""
+This is the configuration file for the parser and graph modules.
+"""
+
 ME = "" # Your name, as it appears on Facebook
 API_KEY = "" # Api Key from gender-api.com (optional)
 START_DATE = "1/1/16" # date to start analysis from. Format must be MM/DD/YY


### PR DESCRIPTION
Facebook's new data dump format has a folder of messages with a separate HTML file for each conversation, rather than a single large file with all of them.

I've updated the parser and instructions to use this folder instead to go through the files and collect/store the same information for the grapher so that it's compatible with the new archive format.